### PR TITLE
Extend Component conformance to String

### DIFF
--- a/Sources/NSAttributedStringBuilder/NSAttributedStringBuilder.swift
+++ b/Sources/NSAttributedStringBuilder/NSAttributedStringBuilder.swift
@@ -20,10 +20,20 @@ public struct NSAttributedStringBuilder {
         }
         return mas
     }
+
+    public static func buildBlock(_ strings: String...) -> NSAttributedString {
+        return strings.joined().attributedString
+    }
 }
 
 extension NSAttributedString {
     public convenience init(@NSAttributedStringBuilder _ builder: () -> NSAttributedString) {
         self.init(attributedString: builder())
     }
+}
+
+extension String: Component {
+    public var string: String { self }
+    public var attributes: Attributes { [:] }
+    public var attributedString: NSAttributedString { NSAttributedString(string: self) }
 }

--- a/Tests/NSAttributedStringBuilderTests/NSAttributedStringBuilderTests.swift
+++ b/Tests/NSAttributedStringBuilderTests/NSAttributedStringBuilderTests.swift
@@ -14,7 +14,34 @@ final class NSAttributedStringBuilderTests: XCTestCase {
             AText(" with Swift")
         }
 
+        let sut2 = NSAttributedString {
+            "Hello world"
+            " with Swift"
+        }
+
         XCTAssertTrue(sut.isEqual(testData))
+        XCTAssertTrue(sut2.isEqual(sut))
+    }
+
+    func testInitWithStringAndAText() {
+        let testData: NSAttributedString = {
+            let mas = NSMutableAttributedString(string: "Hello world")
+            mas.append(NSAttributedString(string: " with Swift"))
+            return mas
+        }()
+
+        let sut = NSAttributedString {
+            AText("Hello world")
+            " with Swift"
+        }
+
+        let sut2 = NSAttributedString {
+            "Hello world"
+            AText(" with Swift")
+        }
+
+        XCTAssertTrue(sut.isEqual(testData))
+        XCTAssertTrue(sut2.isEqual(sut))
     }
 
     func testInitWithTextAndLink() {
@@ -33,10 +60,19 @@ final class NSAttributedStringBuilderTests: XCTestCase {
             Link("Apple", url: URL(string: "https://www.apple.com")!)
         }
 
+        let sut2 = NSAttributedString {
+            "Here is a link to "
+                .foregroundColor(.brown)
+            Link("Apple", url: URL(string: "https://www.apple.com")!)
+        }
+
         XCTAssertTrue(sut.isEqual(testData))
+        XCTAssertTrue(sut2.isEqual(sut))
     }
 
     static var allTests = [
+        ("testInitWithTwoAText", testInitWithTwoAText),
+        ("testInitWithStringAndAText", testInitWithStringAndAText),
         ("testInitWithTextAndLink", testInitWithTextAndLink)
     ]
 }


### PR DESCRIPTION
Constructing NSAttributedString with `AText` seems a little bit verbose compared to a String literal:
```Swift
let attrStr = NSAttributedString {
    "DON'T"
        .foregroundColor(.blue)
    "PANIC"
}
```