### PR TITLE
Add ATextGroup

### DIFF
--- a/Sources/NSAttributedStringBuilder/Components/AText.swift
+++ b/Sources/NSAttributedStringBuilder/Components/AText.swift
@@ -1,7 +1,7 @@
 #if canImport(UIKit)
-import UIKit
+    import UIKit
 #elseif canImport(AppKit)
-import AppKit
+    import AppKit
 #endif
 
 public typealias AText = NSAttributedString.AttrText
@@ -18,6 +18,6 @@ public extension NSAttributedString {
         // MARK: Public
 
         public let string: String
-        public var attributes: Attributes
+        public let attributes: Attributes
     }
 }

--- a/Sources/NSAttributedStringBuilder/Components/AText.swift
+++ b/Sources/NSAttributedStringBuilder/Components/AText.swift
@@ -1,7 +1,7 @@
 #if canImport(UIKit)
-    import UIKit
+import UIKit
 #elseif canImport(AppKit)
-    import AppKit
+import AppKit
 #endif
 
 public typealias AText = NSAttributedString.AttrText
@@ -18,6 +18,6 @@ public extension NSAttributedString {
         // MARK: Public
 
         public let string: String
-        public let attributes: Attributes
+        public var attributes: Attributes
     }
 }

--- a/Sources/NSAttributedStringBuilder/Components/ATextGroup.swift
+++ b/Sources/NSAttributedStringBuilder/Components/ATextGroup.swift
@@ -1,0 +1,45 @@
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+public typealias ATextGroup = NSAttributedString.AttrTextGroup
+
+public extension NSAttributedString {
+    struct AttrTextGroup: Component {
+        public let string: String = ""
+        public let attributes: Attributes = [:]
+
+        public var attributedTexts: [AttrText]
+        public var attributedString: NSAttributedString {
+            let mas = NSMutableAttributedString(string: "")
+            for attributedText in attributedTexts {
+                mas.append(attributedText.attributedString)
+            }
+            return mas
+        }
+
+        public init(@AttrTextGroupBuilder attrTextGroupBuilder: () -> [AttrText]) {
+            attributedTexts = attrTextGroupBuilder()
+        }
+
+        public func attributes(_ newAttributes: Attributes) -> Component {
+            guard attributedTexts.count > 0 else { return self }
+            var group = self
+            for attribute in newAttributes {
+                for index in 0 ..< group.attributedTexts.count {
+                    group.attributedTexts[index].attributes[attribute.key] = attribute.value
+                }
+            }
+            return group
+        }
+    }
+}
+
+@resultBuilder
+public enum AttrTextGroupBuilder {
+    public static func buildBlock(_ components: Component...) -> [AText] {
+        components.compactMap { $0 as? AText }
+    }
+}

--- a/Sources/NSAttributedStringBuilder/Components/Component.swift
+++ b/Sources/NSAttributedStringBuilder/Components/Component.swift
@@ -1,9 +1,9 @@
 #if canImport(UIKit)
-import UIKit
-public typealias Size = CGSize
+    import UIKit
+    public typealias Size = CGSize
 #elseif canImport(AppKit)
-import AppKit
-public typealias Size = NSSize
+    import AppKit
+    public typealias Size = NSSize
 #endif
 
 public protocol Component {
@@ -18,11 +18,15 @@ public enum Ligature: Int {
     case `default` = 1
 
     #if canImport(AppKit)
-    case all = 2 // Value 2 is unsupported on iOS
+        case all = 2 // Value 2 is unsupported on iOS
     #endif
 }
 
 public extension Component {
+    private func build(_ string: String, attributes: Attributes) -> Component {
+        AText(string, attributes: attributes)
+    }
+
     var attributedString: NSAttributedString {
         NSAttributedString(string: string, attributes: attributes)
     }
@@ -37,10 +41,6 @@ public extension Component {
             attributes[attribute.key] = attribute.value
         }
         return build(string, attributes: attributes)
-    }
-
-    private func build(_ string: String, attributes: Attributes) -> Component {
-        AText(string, attributes: attributes)
     }
 }
 
@@ -123,9 +123,9 @@ public extension Component {
     }
 
     #if canImport(AppKit)
-    func vertical() -> Component {
-        attributes([.verticalGlyphForm: 1])
-    }
+        func vertical() -> Component {
+            attributes([.verticalGlyphForm: 1])
+        }
     #endif
 }
 
@@ -144,7 +144,8 @@ public extension Component {
         if let mps = attributes[.paragraphStyle] as? NSMutableParagraphStyle {
             return mps
         } else if let ps = attributes[.paragraphStyle] as? NSParagraphStyle,
-                  let mps = ps.mutableCopy() as? NSMutableParagraphStyle {
+                  let mps = ps.mutableCopy() as? NSMutableParagraphStyle
+        {
             return mps
         } else {
             return NSMutableParagraphStyle()
@@ -229,77 +230,79 @@ public extension Component {
     }
 
     #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-    func textBlocks(_ textBlocks: [NSTextBlock]) -> Component {
-        let paragraphStyle = getMutableParagraphStyle()
-        paragraphStyle.textBlocks = textBlocks
-        return self.paragraphStyle(paragraphStyle)
-    }
+        func textBlocks(_ textBlocks: [NSTextBlock]) -> Component {
+            let paragraphStyle = getMutableParagraphStyle()
+            paragraphStyle.textBlocks = textBlocks
+            return self.paragraphStyle(paragraphStyle)
+        }
 
-    func textLists(_ textLists: [NSTextList]) -> Component {
-        let paragraphStyle = getMutableParagraphStyle()
-        paragraphStyle.textLists = textLists
-        return self.paragraphStyle(paragraphStyle)
-    }
+        func textLists(_ textLists: [NSTextList]) -> Component {
+            let paragraphStyle = getMutableParagraphStyle()
+            paragraphStyle.textLists = textLists
+            return self.paragraphStyle(paragraphStyle)
+        }
 
-    func tighteningFactorForTruncation(_ tighteningFactorForTruncation: Float) -> Component {
-        let paragraphStyle = getMutableParagraphStyle()
-        paragraphStyle.tighteningFactorForTruncation = tighteningFactorForTruncation
-        return self.paragraphStyle(paragraphStyle)
-    }
+        func tighteningFactorForTruncation(_ tighteningFactorForTruncation: Float) -> Component {
+            let paragraphStyle = getMutableParagraphStyle()
+            paragraphStyle.tighteningFactorForTruncation = tighteningFactorForTruncation
+            return self.paragraphStyle(paragraphStyle)
+        }
 
-    func headerLevel(_ headerLevel: Int) -> Component {
-        let paragraphStyle = getMutableParagraphStyle()
-        paragraphStyle.headerLevel = headerLevel
-        return self.paragraphStyle(paragraphStyle)
-    }
+        func headerLevel(_ headerLevel: Int) -> Component {
+            let paragraphStyle = getMutableParagraphStyle()
+            paragraphStyle.headerLevel = headerLevel
+            return self.paragraphStyle(paragraphStyle)
+        }
     #endif
 }
 
 // MARK: - No 'modifiers' for these keys. Use .attributes() or .attribute(:value:) instead.
 
-// #if canImport(UIKit)
-// let iOSKeys: [NSAttributedString.Key] = [
-//    .UIAccessibilitySpeechAttributeSpellOut, // iOS 13+
-//    .UIAccessibilityTextAttributeContext, // iOS 13+
-//    .accessibilitySpeechIPANotation, // iOS 11.0+
-//    .accessibilitySpeechLanguage, // iOS 7.0+
-//    .accessibilitySpeechPitch, // iOS 7.0+
-//    .accessibilitySpeechPunctuation, // iOS 7.0+
-//    .accessibilitySpeechQueueAnnouncement, // iOS 11.0+
-//    .accessibilityTextCustom, // iOS 11.0+
-//    .accessibilityTextHeadingLevel, // iOS 11.0+
-// ]
-// #endif
-//
-// #if canImport(AppKit) && !targetEnvironment(UIKitForMac)
-// let macOSKeys: [NSAttributedString.Key] = [
-//    .accessibilityAlignment, // macOS 10.12+
-//    .accessibilityAnnotationTextAttribute, // macOS 10.13+
-//    .accessibilityAttachment, // macOS 10.4+, Deprecated
-//    .accessibilityAutocorrected, // macOS 10.7+
-//    .accessibilityBackgroundColor, // macOS 10.4+
-//    .accessibilityCustomText, // macOS 10.13+
-//    .accessibilityFont, // macOS 10.4+
-//    .accessibilityForegroundColor, // macOS 10.4+
-//    .accessibilityLanguage, // macOS 10.13+
-//    .accessibilityLink, // macOS 10.4+
-//    .accessibilityListItemIndex, // macOS 10.11+
-//    .accessibilityListItemLevel, // macOS 10.11+
-//    .accessibilityListItemPrefix, // macOS 10.11+
-//    .accessibilityMarkedMisspelled, // macOS 10.4+
-//    .accessibilityMisspelled, // macOS 10.4+
-//    .accessibilityShadow, // macOS 10.4+
-//    .accessibilityStrikethrough, // macOS 10.4+
-//    .accessibilityStrikethroughColor, // macOS 10.4+
-//    .accessibilitySuperscript, // macOS 10.4+
-//    .accessibilityUnderline, // macOS 10.4+
-//    .accessibilityUnderlineColor, // macOS 10.4+
-//    .cursor, // macOS 10.3+
-//    .glyphInfo, // macOS 10.2+
-//    .markedClauseSegment, // macOS 10.5+
-//    .spellingState, // macOS 10.5+
-//    .superscript, // macOS 10.0+
-//    .textAlternatives, // macOS 10.8+
-//    .toolTip, // macOS 10.3+
-// ]
-// #endif
+/*
+ #if canImport(UIKit)
+ let iOSKeys: [NSAttributedString.Key] = [
+     .UIAccessibilitySpeechAttributeSpellOut, // iOS 13+
+     .UIAccessibilityTextAttributeContext, // iOS 13+
+     .accessibilitySpeechIPANotation, // iOS 11.0+
+     .accessibilitySpeechLanguage, // iOS 7.0+
+     .accessibilitySpeechPitch, // iOS 7.0+
+     .accessibilitySpeechPunctuation, // iOS 7.0+
+     .accessibilitySpeechQueueAnnouncement, // iOS 11.0+
+     .accessibilityTextCustom, // iOS 11.0+
+     .accessibilityTextHeadingLevel, // iOS 11.0+
+ ]
+ #endif
+
+ #if canImport(AppKit) && !targetEnvironment(UIKitForMac)
+ let macOSKeys: [NSAttributedString.Key] = [
+     .accessibilityAlignment, // macOS 10.12+
+     .accessibilityAnnotationTextAttribute, // macOS 10.13+
+     .accessibilityAttachment, // macOS 10.4+, Deprecated
+     .accessibilityAutocorrected, // macOS 10.7+
+     .accessibilityBackgroundColor, // macOS 10.4+
+     .accessibilityCustomText, // macOS 10.13+
+     .accessibilityFont, // macOS 10.4+
+     .accessibilityForegroundColor, // macOS 10.4+
+     .accessibilityLanguage, // macOS 10.13+
+     .accessibilityLink, // macOS 10.4+
+     .accessibilityListItemIndex, // macOS 10.11+
+     .accessibilityListItemLevel, // macOS 10.11+
+     .accessibilityListItemPrefix, // macOS 10.11+
+     .accessibilityMarkedMisspelled, // macOS 10.4+
+     .accessibilityMisspelled, // macOS 10.4+
+     .accessibilityShadow, // macOS 10.4+
+     .accessibilityStrikethrough, // macOS 10.4+
+     .accessibilityStrikethroughColor, // macOS 10.4+
+     .accessibilitySuperscript, // macOS 10.4+
+     .accessibilityUnderline, // macOS 10.4+
+     .accessibilityUnderlineColor, // macOS 10.4+
+     .cursor, // macOS 10.3+
+     .glyphInfo, // macOS 10.2+
+     .markedClauseSegment, // macOS 10.5+
+     .spellingState, // macOS 10.5+
+     .superscript, // macOS 10.0+
+     .textAlternatives, // macOS 10.8+
+     .toolTip, // macOS 10.3+
+ ]
+ #endif
+ */

--- a/Sources/NSAttributedStringBuilder/Components/Component.swift
+++ b/Sources/NSAttributedStringBuilder/Components/Component.swift
@@ -1,15 +1,16 @@
 #if canImport(UIKit)
-    import UIKit
-    public typealias Size = CGSize
+import UIKit
+public typealias Size = CGSize
 #elseif canImport(AppKit)
-    import AppKit
-    public typealias Size = NSSize
+import AppKit
+public typealias Size = NSSize
 #endif
 
 public protocol Component {
     var string: String { get }
     var attributes: Attributes { get }
     var attributedString: NSAttributedString { get }
+    func attributes(_ newAttributes: Attributes) -> Component
 }
 
 public enum Ligature: Int {
@@ -17,15 +18,11 @@ public enum Ligature: Int {
     case `default` = 1
 
     #if canImport(AppKit)
-        case all = 2 // Value 2 is unsupported on iOS
+    case all = 2 // Value 2 is unsupported on iOS
     #endif
 }
 
 public extension Component {
-    private func build(_ string: String, attributes: Attributes) -> Component {
-        AText(string, attributes: attributes)
-    }
-
     var attributedString: NSAttributedString {
         NSAttributedString(string: string, attributes: attributes)
     }
@@ -40,6 +37,10 @@ public extension Component {
             attributes[attribute.key] = attribute.value
         }
         return build(string, attributes: attributes)
+    }
+
+    private func build(_ string: String, attributes: Attributes) -> Component {
+        AText(string, attributes: attributes)
     }
 }
 
@@ -122,9 +123,9 @@ public extension Component {
     }
 
     #if canImport(AppKit)
-        func vertical() -> Component {
-            attributes([.verticalGlyphForm: 1])
-        }
+    func vertical() -> Component {
+        attributes([.verticalGlyphForm: 1])
+    }
     #endif
 }
 
@@ -143,8 +144,7 @@ public extension Component {
         if let mps = attributes[.paragraphStyle] as? NSMutableParagraphStyle {
             return mps
         } else if let ps = attributes[.paragraphStyle] as? NSParagraphStyle,
-                  let mps = ps.mutableCopy() as? NSMutableParagraphStyle
-        {
+                  let mps = ps.mutableCopy() as? NSMutableParagraphStyle {
             return mps
         } else {
             return NSMutableParagraphStyle()
@@ -229,79 +229,77 @@ public extension Component {
     }
 
     #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-        func textBlocks(_ textBlocks: [NSTextBlock]) -> Component {
-            let paragraphStyle = getMutableParagraphStyle()
-            paragraphStyle.textBlocks = textBlocks
-            return self.paragraphStyle(paragraphStyle)
-        }
+    func textBlocks(_ textBlocks: [NSTextBlock]) -> Component {
+        let paragraphStyle = getMutableParagraphStyle()
+        paragraphStyle.textBlocks = textBlocks
+        return self.paragraphStyle(paragraphStyle)
+    }
 
-        func textLists(_ textLists: [NSTextList]) -> Component {
-            let paragraphStyle = getMutableParagraphStyle()
-            paragraphStyle.textLists = textLists
-            return self.paragraphStyle(paragraphStyle)
-        }
+    func textLists(_ textLists: [NSTextList]) -> Component {
+        let paragraphStyle = getMutableParagraphStyle()
+        paragraphStyle.textLists = textLists
+        return self.paragraphStyle(paragraphStyle)
+    }
 
-        func tighteningFactorForTruncation(_ tighteningFactorForTruncation: Float) -> Component {
-            let paragraphStyle = getMutableParagraphStyle()
-            paragraphStyle.tighteningFactorForTruncation = tighteningFactorForTruncation
-            return self.paragraphStyle(paragraphStyle)
-        }
+    func tighteningFactorForTruncation(_ tighteningFactorForTruncation: Float) -> Component {
+        let paragraphStyle = getMutableParagraphStyle()
+        paragraphStyle.tighteningFactorForTruncation = tighteningFactorForTruncation
+        return self.paragraphStyle(paragraphStyle)
+    }
 
-        func headerLevel(_ headerLevel: Int) -> Component {
-            let paragraphStyle = getMutableParagraphStyle()
-            paragraphStyle.headerLevel = headerLevel
-            return self.paragraphStyle(paragraphStyle)
-        }
+    func headerLevel(_ headerLevel: Int) -> Component {
+        let paragraphStyle = getMutableParagraphStyle()
+        paragraphStyle.headerLevel = headerLevel
+        return self.paragraphStyle(paragraphStyle)
+    }
     #endif
 }
 
 // MARK: - No 'modifiers' for these keys. Use .attributes() or .attribute(:value:) instead.
 
-/*
- #if canImport(UIKit)
- let iOSKeys: [NSAttributedString.Key] = [
-     .UIAccessibilitySpeechAttributeSpellOut, // iOS 13+
-     .UIAccessibilityTextAttributeContext, // iOS 13+
-     .accessibilitySpeechIPANotation, // iOS 11.0+
-     .accessibilitySpeechLanguage, // iOS 7.0+
-     .accessibilitySpeechPitch, // iOS 7.0+
-     .accessibilitySpeechPunctuation, // iOS 7.0+
-     .accessibilitySpeechQueueAnnouncement, // iOS 11.0+
-     .accessibilityTextCustom, // iOS 11.0+
-     .accessibilityTextHeadingLevel, // iOS 11.0+
- ]
- #endif
-
- #if canImport(AppKit) && !targetEnvironment(UIKitForMac)
- let macOSKeys: [NSAttributedString.Key] = [
-     .accessibilityAlignment, // macOS 10.12+
-     .accessibilityAnnotationTextAttribute, // macOS 10.13+
-     .accessibilityAttachment, // macOS 10.4+, Deprecated
-     .accessibilityAutocorrected, // macOS 10.7+
-     .accessibilityBackgroundColor, // macOS 10.4+
-     .accessibilityCustomText, // macOS 10.13+
-     .accessibilityFont, // macOS 10.4+
-     .accessibilityForegroundColor, // macOS 10.4+
-     .accessibilityLanguage, // macOS 10.13+
-     .accessibilityLink, // macOS 10.4+
-     .accessibilityListItemIndex, // macOS 10.11+
-     .accessibilityListItemLevel, // macOS 10.11+
-     .accessibilityListItemPrefix, // macOS 10.11+
-     .accessibilityMarkedMisspelled, // macOS 10.4+
-     .accessibilityMisspelled, // macOS 10.4+
-     .accessibilityShadow, // macOS 10.4+
-     .accessibilityStrikethrough, // macOS 10.4+
-     .accessibilityStrikethroughColor, // macOS 10.4+
-     .accessibilitySuperscript, // macOS 10.4+
-     .accessibilityUnderline, // macOS 10.4+
-     .accessibilityUnderlineColor, // macOS 10.4+
-     .cursor, // macOS 10.3+
-     .glyphInfo, // macOS 10.2+
-     .markedClauseSegment, // macOS 10.5+
-     .spellingState, // macOS 10.5+
-     .superscript, // macOS 10.0+
-     .textAlternatives, // macOS 10.8+
-     .toolTip, // macOS 10.3+
- ]
- #endif
- */
+// #if canImport(UIKit)
+// let iOSKeys: [NSAttributedString.Key] = [
+//    .UIAccessibilitySpeechAttributeSpellOut, // iOS 13+
+//    .UIAccessibilityTextAttributeContext, // iOS 13+
+//    .accessibilitySpeechIPANotation, // iOS 11.0+
+//    .accessibilitySpeechLanguage, // iOS 7.0+
+//    .accessibilitySpeechPitch, // iOS 7.0+
+//    .accessibilitySpeechPunctuation, // iOS 7.0+
+//    .accessibilitySpeechQueueAnnouncement, // iOS 11.0+
+//    .accessibilityTextCustom, // iOS 11.0+
+//    .accessibilityTextHeadingLevel, // iOS 11.0+
+// ]
+// #endif
+//
+// #if canImport(AppKit) && !targetEnvironment(UIKitForMac)
+// let macOSKeys: [NSAttributedString.Key] = [
+//    .accessibilityAlignment, // macOS 10.12+
+//    .accessibilityAnnotationTextAttribute, // macOS 10.13+
+//    .accessibilityAttachment, // macOS 10.4+, Deprecated
+//    .accessibilityAutocorrected, // macOS 10.7+
+//    .accessibilityBackgroundColor, // macOS 10.4+
+//    .accessibilityCustomText, // macOS 10.13+
+//    .accessibilityFont, // macOS 10.4+
+//    .accessibilityForegroundColor, // macOS 10.4+
+//    .accessibilityLanguage, // macOS 10.13+
+//    .accessibilityLink, // macOS 10.4+
+//    .accessibilityListItemIndex, // macOS 10.11+
+//    .accessibilityListItemLevel, // macOS 10.11+
+//    .accessibilityListItemPrefix, // macOS 10.11+
+//    .accessibilityMarkedMisspelled, // macOS 10.4+
+//    .accessibilityMisspelled, // macOS 10.4+
+//    .accessibilityShadow, // macOS 10.4+
+//    .accessibilityStrikethrough, // macOS 10.4+
+//    .accessibilityStrikethroughColor, // macOS 10.4+
+//    .accessibilitySuperscript, // macOS 10.4+
+//    .accessibilityUnderline, // macOS 10.4+
+//    .accessibilityUnderlineColor, // macOS 10.4+
+//    .cursor, // macOS 10.3+
+//    .glyphInfo, // macOS 10.2+
+//    .markedClauseSegment, // macOS 10.5+
+//    .spellingState, // macOS 10.5+
+//    .superscript, // macOS 10.0+
+//    .textAlternatives, // macOS 10.8+
+//    .toolTip, // macOS 10.3+
+// ]
+// #endif

--- a/Tests/NSAttributedStringBuilderTests/AttributedTextGroupTests.swift
+++ b/Tests/NSAttributedStringBuilderTests/AttributedTextGroupTests.swift
@@ -1,0 +1,53 @@
+//
+//  AttributedTextGroupTests.swift
+//
+//
+//  Created by JH on 2022/8/1.
+//
+
+@testable import NSAttributedStringBuilder
+import XCTest
+final class AttributedTextGroupTests: XCTestCase {
+    func test0() {
+        let att1 = NSAttributedString {
+            AText("111")
+                .font(.systemFont(ofSize: 30))
+                .foregroundColor(.black)
+            AText("222")
+                .font(.systemFont(ofSize: 30))
+                .foregroundColor(.black)
+        }
+
+        let att2 = NSAttributedString {
+            ATextGroup {
+                AText("111")
+                AText("222")
+            }
+            .font(.systemFont(ofSize: 30))
+            .foregroundColor(.black)
+        }
+        XCTAssertTrue(att1.isEqual(att2))
+    }
+
+    func test1() {
+        let att1 = NSAttributedString {
+            AText("111")
+                .font(.systemFont(ofSize: 30))
+                .foregroundColor(.black)
+            AText("222")
+                .font(.systemFont(ofSize: 30))
+                .foregroundColor(.red)
+        }
+
+        let att2 = NSAttributedString {
+            ATextGroup {
+                AText("111")
+                    .foregroundColor(.black)
+                AText("222")
+                    .foregroundColor(.red)
+            }
+            .font(.systemFont(ofSize: 30))
+        }
+        XCTAssertTrue(att1.isEqual(att2))
+    }
+}

--- a/Tests/NSAttributedStringBuilderTests/AttributedTextGroupTests.swift
+++ b/Tests/NSAttributedStringBuilderTests/AttributedTextGroupTests.swift
@@ -50,4 +50,32 @@ final class AttributedTextGroupTests: XCTestCase {
         }
         XCTAssertTrue(att1.isEqual(att2))
     }
+    
+    func test2() {
+        
+        let att1 = NSAttributedString {
+            AText("111")
+                .backgroundColor(.blue)
+            AText("222")
+                .font(.systemFont(ofSize: 18, weight: .semibold))
+                .backgroundColor(.blue)
+            AText("333")
+                .font(.systemFont(ofSize: 18, weight: .semibold))
+                .backgroundColor(.blue)
+                
+        }
+        
+        let att2 = NSAttributedString {
+            ATextGroup {
+                AText("111")
+                ATextGroup {
+                    AText("222")
+                    AText("333")
+                }
+                .font(.systemFont(ofSize: 18, weight: .semibold))
+            }
+            .backgroundColor(.blue)
+        }
+        XCTAssertTrue(att1.isEqual(att2))
+    }
 }


### PR DESCRIPTION
You can use `ATextGroup` when multiple `AText`s use the same property (e.g. font, background), and you can set different properties for `AText` in the Group

```swift
 ATextGroup {
    AText("111")
    AText("222")
}
.font(.systemFont(ofSize: 30))
.foregroundColor(.black)

ATextGroup {
    AText("111")
    .foregroundColor(.black)
    AText("222")
    .foregroundColor(.red)
}
.font(.systemFont(ofSize: 30))

ATextGroup {
    AText("111")
    ATextGroup {
        AText("222")
        AText("333")
    }
    .font(.systemFont(ofSize: 18, weight: .semibold))
}
.backgroundColor(.blue)
```